### PR TITLE
Added computation continuation from output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ The program arguments should be :
 
 ```nBodyProblem [options] initFile [outputFile]```
 
-The `initFile` contains the presets of the simultation, it has to be specified. The `outputFile` will contains the trajectories of the bodies, its default value is `out.csv`
+The `initFile` contains the presets of the simultation, it has to be specified. The `outputFile` will contains the trajectories of the bodies, its default value is `out.csv`. If it already exists the program will continue the computation from the end of this file.
 
 ### Program options
 
 The program options are the following :
 
-* `-euler` Uses the explicit Euler integrator
-* `-taylor` Uses a 4-order Taylor serie
-* `-symplectic4` Uses a 4-order symplectic integrator
-* `-symplectic6` Uses a 6-order symplectic integrator
-* `-energy` Corrects the energy of the system
+* `--euler` Uses the explicit Euler integrator
+* `-t` or `--taylor` Uses a 4-order Taylor serie
+* `--symplectic4` Uses a 4-order symplectic integrator
+* `-s` or `--symplectic6` Uses a 6-order symplectic integrator
+* `-e` or `--energy` Corrects the energy of the system
+* `-o` or `--overwrite` The output file will be overwritten
 
 The default integrator running is the classic 4-order Runge-Kutta method
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@ int main(int argc, char *argv[])
     string initFilename,outFilename="out.csv";
     ComputationMethod computationMethod = RungeKutta4;
     bool firstArgGiven = false;
+    bool overwrite = false;
 
     for (int iarg=1; iarg<argc; iarg++)
     {
@@ -17,32 +18,36 @@ int main(int argc, char *argv[])
             if (strcmp(argv[iarg],"-h")==0 || strcmp(argv[iarg],"--help")==0 )
             {
                 cout << "Usage : nBodyProblem [options] initFile [outputFile]" << endl << endl \
-                << "Options : " << endl << "\t -euler \t uses the explicit Euler integrator" << endl << "\t -taylor \t Uses a 4-order Taylor serie" << endl \
-                << "\t -symplectic4 \t Uses a 4-order symplectic integrator" << endl << "\t -symplectic6 \t Uses a 6-order symplectic integrator" << endl \
-                 << "\t -energy \t corrects the energy" << endl \
+                << "Options : " << endl << "\t --euler \t\t Uses the explicit Euler integrator" << endl << "\t -t --taylor \t\t Uses a 4-order Taylor serie" << endl \
+                << "\t --symplectic4 \t\t Uses a 4-order symplectic integrator" << endl << "\t -s --symplectic6 \t Uses a 6-order symplectic integrator" << endl \
+                 << "\t -e --energy \t\t Corrects the energy" << endl << "\t -o --overwrite \t Overwrites the output file instead of continuing the computation" \
                  << endl << "The default integrator is the classic RK4" << endl;
                 exit(EXIT_SUCCESS);
             }
-            else if (strcmp(argv[iarg],"-euler")==0)
+            else if (strcmp(argv[iarg],"--euler")==0)
             {
                 computationMethod.integrator = Integrator::Euler;
             }
-            else if (strcmp(argv[iarg],"-taylor")==0)
+            else if (strcmp(argv[iarg],"--taylor")==0 || strcmp(argv[iarg],"-t")==0)
             {
                 computationMethod.integrator = Integrator::Taylor;
                 computationMethod.order = 4;
             }
-            else if (strcmp(argv[iarg],"-symplectic4")==0)
+            else if (strcmp(argv[iarg],"--symplectic4")==0)
             {
                 computationMethod.integrator = Integrator::Symplectic4;
             }
-            else if (strcmp(argv[iarg],"-symplectic6")==0)
+            else if (strcmp(argv[iarg],"--symplectic6")==0 || strcmp(argv[iarg],"-s")==0)
             {
                 computationMethod.integrator = Integrator::Symplectic6;
             }
-            else if (strcmp(argv[iarg],"-energy")==0)
+            else if (strcmp(argv[iarg],"--energy")==0 || strcmp(argv[iarg],"-e")==0)
             {
                 computationMethod.energie = true;
+            }
+            else if (strcmp(argv[iarg],"--overwrite")==0 || strcmp(argv[iarg],"-o")==0)
+            {
+                overwrite = true;
             }
             else
             {
@@ -74,10 +79,10 @@ int main(int argc, char *argv[])
     NBody system;
     system.computationMethod = computationMethod;
 
-    system.computePreset(initFilename);
+    system.computePreset(initFilename, !overwrite, outFilename);
     cout << "Computation completed" << endl;
 
-    system.save(outFilename);
+    system.save(outFilename, overwrite);
     cout << "File saved" << endl;
 
     return EXIT_SUCCESS;

--- a/src/NBody.cpp
+++ b/src/NBody.cpp
@@ -1,10 +1,11 @@
 #include "NBody.h"
 
 #include "vector3.h"
+#include "rapidcsv.h"
 #include <cmath>
+#include <sys/stat.h>
 #include <iostream>
 #include <fstream>
-#include <iterator>
 #include <string>
 
 using namespace std;
@@ -14,6 +15,12 @@ bool NBody::initialized = false;
 unsigned int NBody::C[NBody::maxn+1][NBody::maxn+1] = {0};
 unsigned int NBody::f[NBody::maxn+1] = {0};
 long double NBody::fInv[NBody::maxn+1] = {0};
+
+inline bool fileExists(string const& filename)
+{
+    struct stat buffer;
+    return (stat (filename.c_str(), &buffer) == 0);
+}
 
 NBody::NBody()
 {
@@ -51,16 +58,18 @@ void NBody::initialize()
     initialized=true;
 }
 
-void NBody::Compute(long double tmax, unsigned int skip)
+
+void NBody::compute(long double tmax, unsigned int skip, long double initTime)
 {
     initEnergy = getEnergie(); // Usefull for energy conservation
     stepFactor = normalStep * (long double)pow((long double)accelerationSum(),stepPower);
     computationDone=false;
-    long double t = 0;
+    long double t = initTime;
+    long double currentStep;
     trajectories = {};
     vector<pair<vector3l,vector3l>> resultatsActuels;
 
-    for (unsigned int i=0; t<tmax; i++)
+    for (unsigned int i=0; t<=tmax+1e-14; i++) // ajust for floating point errors
     {
         if (i%skip==0) // save this point
         {
@@ -70,14 +79,68 @@ void NBody::Compute(long double tmax, unsigned int skip)
             }
             trajectories.push_back( pair<long double,vector<pair<vector3l,vector3l>>>(t,resultatsActuels)  );
         }
-        long double currentStep = getStep();
-        if (currentStep==0) {cout << "Error : Delay dropped to 0" << endl; exit(1);}
+        currentStep = getStep();
+        if (currentStep==0) {cout << "Error : Delay dropped to 0" << endl; exit(EXIT_FAILURE);}
         t += currentStep;
-        tick();
+        if (t<=tmax+2e-15) tick(); // no need to tick, the result will be ignored
         cout << "\r" << int(100*t/tmax) << " %";
     }
     cout << "\r";
     computationDone=true;
+}
+
+void NBody::computePreset(const string& initFilename, bool continueFromFile, const std::string& outFilename)
+{
+    body = {};
+
+    // Init file read
+    rapidcsv::Document initFile(initFilename);
+    vector<long double> presetBodyLine = initFile.GetRow<long double>(0); // First line
+    unsigned int lineSize = presetBodyLine.size();
+    if (lineSize!=3 && lineSize!=4 && lineSize!=5) {cout << "Error : the first line size is " << lineSize << ", should be between 3 and 5" << endl; exit(EXIT_FAILURE);}
+    unsigned int n = presetBodyLine[0];
+    normalStep = presetBodyLine[1];
+    long double computationTime = presetBodyLine[2];
+    unsigned int skip=100;
+    if (lineSize>=4) skip = presetBodyLine[3];
+    if (lineSize==5) Body::G = presetBodyLine[4];
+
+    bool loadFromOut=false;
+    vector<long double> lastOutputLine;
+    long double initTime=0;
+
+    if (continueFromFile) // Check if there's an unfinished file to start from
+    {
+        if (fileExists(outFilename))
+        {
+            rapidcsv::Document outFile(outFilename);
+            lastOutputLine = outFile.GetRow<long double>(outFile.GetRowCount()-1);
+            if (lastOutputLine.size() != 6*n+1) {cout << "Error : the last line of output file size is " << lastOutputLine.size() <<", expected " << 6*n+1 << endl; exit(EXIT_FAILURE);}
+            loadFromOut = true;
+        }
+    }
+
+    for (unsigned int i=0; i<n; i++) // Load body data
+    {
+        presetBodyLine = initFile.GetRow<long double>(1+i);
+        if (presetBodyLine.size()!=7) {cout << "Error : the size body number " << i << "'s line does not have the correct size (7 numbers expected)" << endl; exit(EXIT_FAILURE);}
+
+        if (loadFromOut)
+        {
+            initTime = lastOutputLine[0];
+            body.push_back(Body( vector3l(lastOutputLine[1+6*i],lastOutputLine[2+6*i],lastOutputLine[3+6*i]), \
+                vector3l(lastOutputLine[4+6*i],lastOutputLine[5+6*i],lastOutputLine[6+6*i]), presetBodyLine[6] ));
+        }
+        else
+        {
+            body.push_back(Body( vector3l(presetBodyLine[0],presetBodyLine[1],presetBodyLine[2]), \
+                vector3l(presetBodyLine[3],presetBodyLine[4],presetBodyLine[5]), presetBodyLine[6] ));
+        }
+    }
+
+    linkAll();
+
+    compute(computationTime,skip,initTime);
 }
 
 long double NBody::getRecordedStep(int i)
@@ -348,11 +411,11 @@ bool NBody::getComputationDone()
     return computationDone;
 }
 
-void NBody::save(string filename)
+void NBody::save(const string& filename, bool overwrite)
 {
     string resultsString;
     long double pmax(0),vmax(0);
-    for (unsigned int i=0; i<trajectories.size(); i++)
+    for (unsigned int i=(!overwrite); i<trajectories.size(); i++) // skip the first if we are continuing a computation, so the line isn't duplicated
     {
         resultsString.append(to_string(trajectories[i].first)); // time
         for (unsigned int j=0; j<body.size(); j++)
@@ -365,8 +428,11 @@ void NBody::save(string filename)
         resultsString.append("\n");
     }
 
-    ofstream fichier(filename);
-    fichier << body.size() << "," << trajectories.size() << "," << pmax << "," << vmax << endl; // first line
+    ofstream fichier;
+    if (overwrite) fichier = ofstream(filename);
+    else fichier = ofstream(filename, ofstream::app);
+
+    if (!fileExists(filename) || overwrite) fichier << body.size() << "," << trajectories.size() << "," << pmax << "," << vmax << endl; // first line
     fichier << resultsString; // Enter the results
 
 }

--- a/src/NBody.cpp
+++ b/src/NBody.cpp
@@ -428,11 +428,21 @@ void NBody::save(const string& filename, bool overwrite)
         resultsString.append("\n");
     }
 
+    bool outputExists = fileExists(filename);
     ofstream fichier;
+    bool writeFirstLine = true;
     if (overwrite) fichier = ofstream(filename);
     else fichier = ofstream(filename, ofstream::app);
 
-    if (!fileExists(filename) || overwrite) fichier << body.size() << "," << trajectories.size() << "," << pmax << "," << vmax << endl; // first line
+    if (!overwrite) // if we don't overwrite the file
+    {
+        if (outputExists) // Check if there's an unfinished file to start from
+        {
+            writeFirstLine = false;
+        }
+    }
+
+    if (writeFirstLine) fichier << body.size() << "," << trajectories.size() << "," << pmax << "," << vmax << endl; // first line
     fichier << resultsString; // Enter the results
 
 }

--- a/src/NBody.h
+++ b/src/NBody.h
@@ -66,12 +66,16 @@ class NBody
 {
     public:
 
+        // Basic
         NBody();
         std::vector<Body> body;
+        void linkAll();
 
+        // Step computation
         void tick(long double delta);
         void tick();
 
+        // Step configuration
         long double getStep();
         long double normalStep;
         long double stepFactor;
@@ -79,27 +83,35 @@ class NBody
         ComputationMethod computationMethod;
         long double positionPulseRatio;
 
-        void Compute(long double tmax, unsigned int skip);
+        // Main computation premade functions
+        void compute(long double tmax, unsigned int skip, long double initTime = 0);
+        void computePreset(const std::string& initFilename, bool continueFromFile=false, const std::string& outFilename="out.csv");
+
+        // Trajectories management
         std::vector<std::pair<vector3l,vector3l>> getResults();
         long double getRecordedStep(int i=1);
         unsigned int recordedTrajectoryIndex;
         bool getComputationDone();
-        void save(std::string filename="trajectoire.csv");
+        void save(const std::string& filename="trajectoire.csv", bool overwrite = true);
 
+        // Usefull Physics stuff
         long double getEnergie();
         long double accelerationSum();
-        void linkAll();
 
+        // Math stuff
         unsigned int binomialCoeff(unsigned int n, unsigned int k);
         unsigned int factorial(unsigned int n);
         static void initialize();
         static const unsigned int maxn = 32;
 
     protected:
-        std::vector< std::pair<long double,std::vector<  std::pair<vector3l,vector3l> >> > trajectories; // Choix du temps, puis du couple de vecteur, puis position/vitesse
+
+        std::vector< std::pair<long double,std::vector<  std::pair<vector3l,vector3l> >> > trajectories; // Time, then body, then position or velocity
+        long double initEnergy;
+
         bool computationDone;
         static bool initialized;
-        long double initEnergy;
+
         static unsigned int C[maxn + 1][maxn + 1];
         static unsigned int f[maxn+1];
         static long double fInv[maxn+1];


### PR DESCRIPTION
Now if the output file already exists, the computation starts from where the output file ends. Use `-o` or `--overwrite` to avoid this if you want to overwrite the file. Also modified the options with -- when words